### PR TITLE
Refactor main pages and expand site info

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,11 +3,30 @@
 <head>
   <meta charset="UTF-8">
   <title>Sobre mí</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Información sobre el autor y propósito de este espacio digital minimalista.">
+  <meta name="author" content="MarcoS9309">
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap" rel="stylesheet">
+  <style>
+    body {
+      font-family: 'Lato', Arial, Helvetica, sans-serif;
+    }
+  </style>
 </head>
 <body>
-  <h1>Sobre mí</h1>
-<p>Soy un individuo que aprecia la sencillez en la web. Escribo textos, comparto pensamientos y evito efectos superfluos. Leo y reescribo, si es copiar y pegar cometo un error; en realidad, no es copiar y pegar, eso lo dejé atrás en mi juventud.</p>
-  <hr>
-  <a href="index.html">Volver al inicio</a>
+  <header>
+    <h1>Sobre mí</h1>
+    <nav>
+      <a href="index.html">Inicio</a>
+    </nav>
+  </header>
+  <main>
+    <p>Soy un individuo que aprecia la sencillez en la web. Escribo textos, comparto pensamientos y evito efectos superfluos. Leo y reescribo, si es copiar y pegar cometo un error; en realidad, no es copiar y pegar, eso lo dejé atrás en mi juventud.</p>
+    <p>Este espacio surge como un ejercicio de escritura y experimentación personal. Aquí comparto enlaces a diarios, reflexiones y notas breves que me ayudan a organizar ideas dentro del caos digital.</p>
+    <p>Si deseas ponerte en contacto o comentar alguna publicación, puedes hacerlo por correo.</p>
+  </main>
+  <footer>
+    <a href="mailto:alligator9339@protonmail.com">Escríbeme</a>
+  </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,71 +1,84 @@
 <!DOCTYPE html>
 <html lang="es">
-    <head>
-        <meta charset="UTF-8">
-        <title>¡Mi sitio absurdamente elemental!</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <!-- Google Fonts: Lato -->
-        <link href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap" rel="stylesheet">
-        <style>
-            body {
-                font-family: 'Lato', Arial, Helvetica, sans-serif;
-            }
-        </style>
-    </head>
-    <body>
-        <h1>¡Saludos y bienvenido a mi espacio intrincado y sencillo!</h1>
+  <head>
+    <meta charset="UTF-8">
+    <title>¡Mi sitio absurdamente elemental!</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Blog personal minimalista con enlaces a escritos recientes y reflexiones sobre el caos digital.">
+    <meta name="author" content="MarcoS9309">
+    <!-- Google Fonts: Lato -->
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap" rel="stylesheet">
+    <style>
+      body {
+        font-family: 'Lato', Arial, Helvetica, sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>¡Saludos y bienvenido a mi espacio intrincado y sencillo!</h1>
+      <nav>
+        <a href="about.html">Sobre mí</a>
+      </nav>
+    </header>
+
+    <main>
+      <section>
         <p>
-            No hay ornamentos externos, ni guiones, ni imágenes superfluas. Solo HTML puro, claro y ágil.  
-            Si esperabas orden, lo siento: <b>la entropía digital gobierna aquí</b>.  
-            ¿Minimalismo? Sí. ¿Coherencia? A veces. ¿Autoayuda? Más bien, auto-sabotaje.
+          No hay ornamentos externos, ni guiones, ni imágenes superfluas. Solo HTML puro, claro y ágil.
+          Si esperabas orden, lo siento: <b>la entropía digital gobierna aquí</b>.
+          ¿Minimalismo? Sí. ¿Coherencia? A veces. ¿Autoayuda? Más bien, auto-sabotaje.
         </p>
         <ul>
-            <li>Ausencia de estilos externos, como un espíritu despojado.</li>
-            <li>Carencia de tipografías decorativas, como pensamientos sin disfraz.</li>
-            <li>Falta de estructuras predefinidas, como ideas libres… o como mi agenda.</li>
-            <li>Solo palabras, encabezados, listas y enlaces, como una conversación honesta (o un monólogo interior digno de Raskólnikov).</li>
-            <li>La navegación es un laberinto, pero sin minotauro. O sí, pero dormido.</li>
+          <li>Ausencia de estilos externos, como un espíritu despojado.</li>
+          <li>Carencia de tipografías decorativas, como pensamientos sin disfraz.</li>
+          <li>Falta de estructuras predefinidas, como ideas libres… o como mi agenda.</li>
+          <li>Solo palabras, encabezados, listas y enlaces, como una conversación honesta (o un monólogo interior digno de Raskólnikov).</li>
+          <li>La navegación es un laberinto, pero sin minotauro. O sí, pero dormido.</li>
         </ul>
         <p>
-            ¿Buscas sentido, dirección, propósito? Aquí tampoco hay.  
-            Pero hay textos. Hay enlaces. Hay confusión existencial y café frío.  
-            Este blog es una muestra de lo que sucede cuando la procrastinación y el perfeccionismo se enfrentan y ambos pierden.
+          ¿Buscas sentido, dirección, propósito? Aquí tampoco hay.
+          Pero hay textos. Hay enlaces. Hay confusión existencial y café frío.
+          Este blog es una muestra de lo que sucede cuando la procrastinación y el perfeccionismo se enfrentan y ambos pierden.
         </p>
         <blockquote>
-            “Ordenar la web es fácil”, me dijeron.  
-            Y yo, como buen personaje dostoievskiano, decidí que el caos tiene más personalidad.
+          “Ordenar la web es fácil”, me dijeron.
+          Y yo, como buen personaje dostoievskiano, decidí que el caos tiene más personalidad.
         </blockquote>
+      </section>
 
+      <section>
         <h2>Escritos recientes</h2>
         <ul>
-            <li><a href="31-07-2025-Julio.html">31-07-2025 — Julio</a></li>
-            <li><a href="29-07-2025-Jatari.html">29-07-2025 — Jatari</a></li>
-            <li><a href="26-07-2025-Oportunidades.html">26-07-2025 — Oportunidades</a></li>
-            <li><a href="24-07-2025-Casa.html">24-07-2025 — Responsabilidades del Día</a></li>
-            <li><a href="17-07-2025-Nostalgia.html">17-07-2025 — El Silencio Tras la Despedida</a></li>
-            <li><a href="2-08-2025-NuevaIA.html">2-08-2025 — Otro camino</a></li>
-            <li><a href="01-08-2025-UNO.html">01-08-2025 — Diario de Agosto</a></li>
-            <li><a href="17-07-2025-Expriecia.html">17-07-2025 — Diario Personal / Experiencia</a></li>
-            <li><a href="30-07-2025-Diaro_Docente.html">30-07-2025 — Diario Docente</a></li>
+          <li><a href="escritos/31-07-2025-Julio.html">31-07-2025 — Julio</a></li>
+          <li><a href="escritos/29-07-2025-Jatari.html">29-07-2025 — Jatari</a></li>
+          <li><a href="escritos/26-07-2025-Oportunidades.html">26-07-2025 — Oportunidades</a></li>
+          <li><a href="escritos/24-07-2025-Casa.html">24-07-2025 — Responsabilidades del Día</a></li>
+          <li><a href="escritos/17-07-2025-Nostalgia.html">17-07-2025 — El Silencio Tras la Despedida</a></li>
+          <li><a href="escritos/2-08-2025-NuevaIA.html">2-08-2025 — Otro camino</a></li>
+          <li><a href="escritos/01-08-2025-UNO.html">01-08-2025 — Diario de Agosto</a></li>
+          <li><a href="escritos/17-07-2025-Expriecia.html">17-07-2025 — Diario Personal / Experiencia</a></li>
+          <li><a href="escritos/30-07-2025-Diaro_Docente.html">30-07-2025 — Diario Docente</a></li>
         </ul>
+      </section>
+    </main>
 
-        <hr>
-        <p>
-            Si alguno de estos enlaces no funciona, no es un error, es un homenaje a mi falta de habilidades organizativas.<br>
-            Si encuentras lógica en el orden, por favor, avísame.  
-            <b>He hecho lo posible por ordenar, pero mi mente es como San Petersburgo: niebla, callejones y tranvías en sentido contrario.</b>
-        </p>
-        <p>
-            <a href="mailto:alligator9339@protonmail.com">Escríbeme</a>
-            | 
-            <a href="https://github.com/MarcoS9309">Mi GitHub</a>
-        </p>
-        <hr>
-        <p>
-            Inspirado por <a href="https://motherfuckingwebsite.com/">Motherfucking Website</a><br>
-            y por esa voz interior que me susurra:  
-            <em>“Un día lo ordenarás todo. O no. Y tampoco pasa nada.”</em>
-        </p>
-    </body>
+    <footer>
+      <p>
+        Si alguno de estos enlaces no funciona, no es un error, es un homenaje a mi falta de habilidades organizativas.<br>
+        Si encuentras lógica en el orden, por favor, avísame.
+        <b>He hecho lo posible por ordenar, pero mi mente es como San Petersburgo: niebla, callejones y tranvías en sentido contrario.</b>
+      </p>
+      <p>
+        <a href="mailto:alligator9339@protonmail.com">Escríbeme</a> |
+        <a href="https://github.com/MarcoS9309">Mi GitHub</a>
+      </p>
+      <p>
+        Inspirado por <a href="https://motherfuckingwebsite.com/">Motherfucking Website</a><br>
+        y por esa voz interior que me susurra:
+        <em>“Un día lo ordenarás todo. O no. Y tampoco pasa nada.”</em>
+      </p>
+    </footer>
+  </body>
 </html>
 


### PR DESCRIPTION
## Summary
- restructure index and about pages with semantic HTML sections
- add meta description and author tags for better context
- fix navigation and point recent posts to the escritos folder

## Testing
- `npx --yes htmlhint index.html about.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68961be6eaec8332ae556cb8177a40b5